### PR TITLE
Add GitHub Skills activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills with GitHub. Part of the GitHub Certifications program to help with college applications.",
+        "schedule": "Mondays and Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Description
This PR adds the missing "GitHub Skills" activity that was announced by the principal.

## Changes
- Added "GitHub Skills" activity to the activities list
- Description mentions the GitHub Certifications program
- Schedule: Mondays and Wednesdays, 3:30 PM - 5:00 PM
- Max capacity: 25 students
- Ready for student registrations

## Fixes
Closes #6

## Context
Students were unable to sign up for the GitHub Skills activity after it was announced. This was time-sensitive as registrations close this week.